### PR TITLE
Choose game feature

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,8 +20,6 @@ def display_question():
     engine.current_index = current_question
     engine.score = player_score
     question = engine.get_current_question()
-    
-
 
     if request.method == 'POST':
         selected = int(request.form.get("answer"))
@@ -41,8 +39,6 @@ def display_question():
         question = engine.get_current_question()
     else:
         return render_template("results.html", player_score=player_score)
-
-        
 
     return render_template(
         "start.html",

--- a/src/app.py
+++ b/src/app.py
@@ -62,11 +62,19 @@ def display_question():
 
 @app.route('/custom', methods=['GET', 'POST'])
 def custom_game():
-    """
-    In memory collector for custom questions.
-    Session list to be replaced with SQLite persistence later.
-    """
+    if request.args.get('reset') == 'true':
+        session.pop('custom_set_name', None)
+        session.pop('custom_questions', None)
+        return render_template('custom_game.html', success=False)
+
     if request.method == 'POST':
+        # name the set if not done yet
+        if 'set_name' in request.form:
+            session['custom_set_name'] = request.form['set_name']
+            session['custom_questions'] = []  # Initialize fresh list
+            return render_template('custom_game.html', success=False)
+
+        # add a question
         q = {
             "category": "Custom",
             "prompt": request.form['prompt'],
@@ -79,14 +87,12 @@ def custom_game():
             "answer": int(request.form['correct'])
         }
 
-        # store in memory for now
         custom_qs = session.get('custom_questions', [])
         custom_qs.append(q)
         session['custom_questions'] = custom_qs
 
-        # re-render template with success flag
         return render_template('custom_game.html', success=True)
-    
+
     return render_template('custom_game.html', success=False)
 
 @app.route('/results')

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, session
+from flask import Flask, render_template, request, session, redirect
 from game.game_engine import GameEngine
 
 app = Flask(__name__)
@@ -10,13 +10,6 @@ def home():
 
 @app.route('/start', methods=['GET', 'POST'])
 def display_question():
-    #placeholder question until we load from engine
-    
-      # Load questions from JSON file
-    question = {
-        "prompt": "What is the capital of France?",
-        "options": ["Berlin", "Madrid", "Paris", "Rome"]
-    }
 
     feedback = None
     player_score = int(request.form.get("current_score", 0))
@@ -35,12 +28,11 @@ def display_question():
 
         print(question.is_correct(selected))
         
-        # correct_answer = 2 #Paris
         if selected and question.is_correct(selected):
             feedback = { "correct": True, "message": "Correct!" }
             player_score += 1
         else:
-            feedback = { "correct": False, "message": "Wrong! Try again." }
+            feedback = { "correct": False, "message": "Wrong!" }
         current_question += 1
         engine.current_index = current_question
         
@@ -73,7 +65,7 @@ def custom_game():
             session['custom_set_name'] = request.form['set_name']
             session['custom_questions'] = []  # Initialize fresh list
             return render_template('custom_game.html', success=False)
-
+        
         # add a question
         q = {
             "category": "Custom",
@@ -91,6 +83,11 @@ def custom_game():
         custom_qs.append(q)
         session['custom_questions'] = custom_qs
 
+        custom_sets = session.get('all_custom_sets', {})
+        set_name = session['custom_set_name']
+        custom_sets[set_name] = custom_qs
+        session['all_custom_sets'] = custom_sets
+
         return render_template('custom_game.html', success=True)
 
     return render_template('custom_game.html', success=False)
@@ -98,6 +95,58 @@ def custom_game():
 @app.route('/results')
 def results():
     return render_template("results.html", player_score=0)
+
+@app.route('/custom-game-play', methods=['GET', 'POST'])
+def custom_game_play():
+    questions = session.get('custom_game_questions', [])
+    index = session.get('custom_current_index', 0)
+    score = session.get('custom_score', 0)
+
+    if index >= len(questions):
+        return render_template('results.html', player_score=score)
+
+    current_question = questions[index]
+    feedback = None
+
+    if request.method == 'POST':
+        selected = int(request.form.get("answer", -1))
+        if selected == current_question['answer']:
+            feedback = {"correct": True, "message": "Correct!"}
+            score += 1
+        else:
+            feedback = {"correct": False, "message": "Wrong!"}
+
+        index += 1
+        session['custom_current_index'] = index
+        session['custom_score'] = score
+
+        if index >= len(questions):
+            return render_template('results.html', player_score=score)
+        current_question = questions[index]
+
+    return render_template("start.html", question=current_question, feedback=feedback,
+                           player_score=score, current_question=index)
+
+@app.route('/start-custom', methods=['POST'])
+def start_custom():
+    set_name = request.form['set_choice']
+    sets = session.get('all_custom_sets', {})
+    questions = sets.get(set_name)
+
+    if not questions:
+        return "Set not found or empty", 400
+
+    session['current_custom_set'] = set_name
+    session['custom_game_questions'] = questions
+    session['custom_current_index'] = 0
+    session['custom_score'] = 0
+
+    return redirect('/custom-game-play')
+
+@app.route('/custom-sets', methods=['GET'])
+def custom_sets():
+    sets = session.get('all_custom_sets', {})
+    return render_template('choose_custom_set.html', sets=sets.keys())
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/src/game/game_engine.py
+++ b/src/game/game_engine.py
@@ -35,13 +35,13 @@ class GameEngine:
         """
         current_question = self.get_current_question()
         if current_question is None:
-            return False  # No question to answer
+            return False  # no question to answer
 
         is_correct = current_question.is_correct(answer_index)
         if is_correct:
             self.score += 1
 
-        self.current_index += 1  # Move to next question
+        self.current_index += 1  # move to next question
         return is_correct
 
     def get_score(self):
@@ -59,7 +59,7 @@ class GameEngine:
 
 
     def load_questions_json(self):
-        #more intelligent way to load questions
+        # more intelligent way to load questions
 
         paths_to_try = ["QuestionRepository.json", "game/QuestionRepository.json", "src/game/QuestionRepository.json"]
 

--- a/src/templates/choose_custom_set.html
+++ b/src/templates/choose_custom_set.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Choose Custom Set</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="game-container">
+        <h1><u>Choose a Custom Set</u></h1>
+
+        {% if sets %}
+        <form method="post" action="/start-custom">
+            <label for="set_choice">Select a set to play:</label>
+            <select name="set_choice" id="set_choice" required>
+                {% for set_name in sets %}
+                <option value="{{ set_name }}">{{ set_name }}</option>
+                {% endfor %}
+            </select>
+            <button type="submit">Start Game</button>
+        </form>
+        {% else %}
+        <p>No custom sets found. Create one first!</p>
+        {% endif %}
+
+        <form action="/" method="get">
+            <button type="submit">Back to Home</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/src/templates/custom_game.html
+++ b/src/templates/custom_game.html
@@ -53,14 +53,13 @@
 
             <button type="submit">Save Question</button>
         </form>
-
         <form action="/" method="get">
             <button type="submit">Back to Home</button>
         </form>
-        <button id="modeToggle">Toggle Night/Day Mode</button>
         <form method="post" action="/custom?reset=true">
             <button type="submit">Start Over</button>
-        </form>
+        </form>        
+        <button id="modeToggle">Toggle Night/Day Mode</button>
         {% endif %}
     </div>
     <script>

--- a/src/templates/custom_game.html
+++ b/src/templates/custom_game.html
@@ -16,6 +16,17 @@
         </div>
         {% endif %}
 
+        {% if not session.get('custom_set_name') %}
+        <h2>Name Your Question Set</h2>
+        <form method="POST">
+            <label for="set_name">Question Set Name</label>
+            <input type="text" id="set_name" name="set_name" required>
+            <button type="submit">Start Creating</button>
+        </form>
+        {% else %}
+        <h2>Set Name: {{ session['custom_set_name'] }}</h2>
+        <h3>Add a Question</h3>
+
         <form method="POST" class="custom-form">
             <label for="prompt">Question Prompt</label>
             <textarea id="prompt" name="prompt" required rows="3"></textarea>
@@ -47,6 +58,10 @@
             <button type="submit">Back to Home</button>
         </form>
         <button id="modeToggle">Toggle Night/Day Mode</button>
+        <form method="post" action="/custom?reset=true">
+            <button type="submit">Start Over</button>
+        </form>
+        {% endif %}
     </div>
     <script>
         const toggleBtn = document.getElementById('modeToggle');

--- a/src/templates/custom_game.html
+++ b/src/templates/custom_game.html
@@ -65,7 +65,7 @@
     <script>
         const toggleBtn = document.getElementById('modeToggle');
 
-        // Load saved mode from localStorage
+        // load saved mode from localStorage
         const savedMode = localStorage.getItem('theme');
         if (savedMode === 'night') {
             document.body.classList.add('night-mode');

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -21,6 +21,9 @@
             <form action="/custom" method="get">
                 <button type="submit">Create Custom Game</button>
             </form>
+            <form action="/custom-sets" method="get">
+                <button type="submit">Play Custom Game</button>
+            </form>
             <button id="modeToggle">Toggle Night/Day Mode</button>
         </div>
     </div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -31,7 +31,7 @@
     <script>
         const toggleBtn = document.getElementById('modeToggle');
 
-        // Load saved mode from localStorage
+        // load saved mode from localStorage
         const savedMode = localStorage.getItem('theme');
         if (savedMode === 'night') {
             document.body.classList.add('night-mode');

--- a/src/templates/results.html
+++ b/src/templates/results.html
@@ -22,7 +22,7 @@
     <script>
         const toggleBtn = document.getElementById('modeToggle');
 
-        // Load saved mode from localStorage
+        // load saved mode from localStorage
         const savedMode = localStorage.getItem('theme');
         if (savedMode === 'night') {
             document.body.classList.add('night-mode');

--- a/src/templates/start.html
+++ b/src/templates/start.html
@@ -50,7 +50,7 @@
     <script>
         const toggleBtn = document.getElementById('modeToggle');
 
-        // Load saved mode from localStorage
+        // load saved mode from localStorage
         const savedMode = localStorage.getItem('theme');
         if (savedMode === 'night') {
             document.body.classList.add('night-mode');


### PR DESCRIPTION
Allows adding named custom question sets + flows to launch and play them.

Player is prompted to name custom set before adding questions. Questions are grouped and stored under that set name in session memory. New route /custom-sets and choose_custom_set.html allows choosing from existing sets.

I tried to add a reset option to the custom question form to start over and make a new custom set, but it's not working properly. Will fix later.